### PR TITLE
feat: implement increase stitch logic for display counter

### DIFF
--- a/src/components/ProgressActionButtons.tsx
+++ b/src/components/ProgressActionButtons.tsx
@@ -6,7 +6,7 @@ interface ProgressActionButtonsProps {
   currentChart: Chart | null
   isViewMode: boolean
   isCompleted: boolean
-  currentStitchInRound: number
+  currentStitchDisplayInRound: number
   totalStitchesInCurrentRound: number
   displayRoundNumber: number
   onNextStitch: () => void
@@ -26,7 +26,7 @@ export const ProgressActionButtons = memo<ProgressActionButtonsProps>(({
   currentChart,
   isViewMode,
   isCompleted,
-  currentStitchInRound,
+  currentStitchDisplayInRound,
   totalStitchesInCurrentRound,
   displayRoundNumber,
   onNextStitch,
@@ -107,7 +107,7 @@ export const ProgressActionButtons = memo<ProgressActionButtonsProps>(({
         
         <div className="flex items-baseline px-6">
           <span className="text-4xl font-bold text-primary">
-            {currentStitchInRound}
+            {currentStitchDisplayInRound}
           </span>
           <span className="text-xl text-text-secondary">
             /{totalStitchesInCurrentRound}

--- a/src/components/ProgressTracking/ActionControls.tsx
+++ b/src/components/ProgressTracking/ActionControls.tsx
@@ -6,7 +6,7 @@ interface ActionControlsProps {
   currentProject: Project | null
   currentChart: Chart | null
   isViewMode: boolean
-  currentStitchInRound: number
+  currentStitchDisplayInRound: number
   totalStitchesInCurrentRound: number
   displayRoundNumber: number
   onNextStitch: () => void
@@ -25,7 +25,7 @@ export const ActionControls = memo<ActionControlsProps>(({
   currentProject,
   currentChart,
   isViewMode,
-  currentStitchInRound,
+  currentStitchDisplayInRound,
   totalStitchesInCurrentRound,
   displayRoundNumber,
   onNextStitch,
@@ -45,7 +45,7 @@ export const ActionControls = memo<ActionControlsProps>(({
       currentChart={currentChart}
       isViewMode={isViewMode}
       isCompleted={currentChart?.isCompleted || false}
-      currentStitchInRound={currentStitchInRound}
+      currentStitchDisplayInRound={currentStitchDisplayInRound}
       totalStitchesInCurrentRound={totalStitchesInCurrentRound}
       displayRoundNumber={displayRoundNumber}
       onNextStitch={onNextStitch}

--- a/src/components/ProgressTrackingView.tsx
+++ b/src/components/ProgressTrackingView.tsx
@@ -54,6 +54,7 @@ export default function ProgressTrackingView() {
   const {
     currentRound,
     currentStitchInRound,
+    currentStitchDisplayInRound,
     totalStitchesInCurrentRound,
     displayRound,
     roundDescription,
@@ -311,7 +312,7 @@ export default function ProgressTrackingView() {
               currentProject={currentProject}
               currentChart={currentChart}
               isViewMode={isViewMode}
-              currentStitchInRound={currentStitchInRound}
+              currentStitchDisplayInRound={currentStitchDisplayInRound}
               totalStitchesInCurrentRound={totalStitchesInCurrentRound}
               displayRoundNumber={displayRoundNumber}
               onNextStitch={handleNextStitch}

--- a/src/hooks/useProgressCalculations.ts
+++ b/src/hooks/useProgressCalculations.ts
@@ -14,6 +14,7 @@ import {
   getChartProgressPercentage,
   getChartCompletedStitches,
 } from '../utils'
+import { calculateStitchDisplayNumber } from '../utils/chart/singleStitchNavigation'
 
 interface UseProgressCalculationsProps {
   currentProject: Project | null
@@ -35,6 +36,7 @@ interface UseProgressCalculationsReturn {
   displayRoundNumber: number
   displayRound: Round | undefined
   currentStitchInRound: number
+  currentStitchDisplayInRound: number
   totalStitchesInCurrentRound: number
   isViewMode: boolean
   
@@ -111,6 +113,7 @@ export function useProgressCalculations({
         displayRoundNumber: 1,
         displayRound: undefined,
         currentStitchInRound: 0,
+        currentStitchDisplayInRound: 0,
         totalStitchesInCurrentRound: 0,
         isViewMode: false
       }
@@ -128,6 +131,7 @@ export function useProgressCalculations({
     const displayRound = pattern.find((r: Round) => r.roundNumber === displayRoundNumber)
     
     const currentStitchInRound = isViewMode ? 0 : currentStitch
+    const currentStitchDisplayInRound = calculateStitchDisplayNumber(currentStitch, displayRound, isViewMode)
     const totalStitchesInCurrentRound = displayRound ? getRoundTotalStitches(displayRound) : 0
     
     
@@ -135,6 +139,7 @@ export function useProgressCalculations({
       displayRoundNumber,
       displayRound,
       currentStitchInRound,
+      currentStitchDisplayInRound,
       totalStitchesInCurrentRound,
       isViewMode
     }

--- a/src/utils/chart/singleStitchNavigation.ts
+++ b/src/utils/chart/singleStitchNavigation.ts
@@ -1,0 +1,151 @@
+import { StitchType, Round, StitchInfo, StitchGroup, PatternItemType } from '../../types'
+import { getSortedPatternItems } from '../pattern/rendering'
+
+/**
+ * 判斷針法是否為加針類型
+ */
+export function isIncreaseStitch(stitchType: StitchType): boolean {
+  return [
+    StitchType.SINGLE_INCREASE,
+    StitchType.HALF_DOUBLE_INCREASE,
+    StitchType.DOUBLE_INCREASE,
+    StitchType.TRIPLE_INCREASE,
+    StitchType.INCREASE,
+    StitchType.KNIT_FRONT_BACK,
+    StitchType.PURL_FRONT_BACK
+  ].includes(stitchType)
+}
+
+/**
+ * 根據當前針目位置和圈數資料，計算顯示的針目數字（考慮加針邏輯）
+ * @param currentStitch 當前針目位置（0-based）
+ * @param displayRound 當前圈數資料
+ * @param isViewMode 是否為查看模式
+ * @returns 顯示的針目數字（0-based）
+ */
+export function calculateStitchDisplayNumber(
+  currentStitch: number,
+  displayRound: Round | undefined,
+  isViewMode: boolean
+): number {
+  if (isViewMode) {
+    return 0
+  }
+
+  if (!displayRound) {
+    return currentStitch
+  }
+
+  // 使用 getSortedPatternItems 獲取正確順序的針法
+  const sortedPatternItems = getSortedPatternItems(displayRound)
+  let displayNumber = 0
+  let stitchIndex = 0
+
+  if (sortedPatternItems.length > 0) {
+    // 使用新的排序格式
+    for (const item of sortedPatternItems) {
+      if (item.type === PatternItemType.STITCH) {
+        const stitch = item.data as StitchInfo
+        
+        // 檢查當前針目是否在這個 stitch 範圍內
+        if (currentStitch >= stitchIndex && currentStitch < stitchIndex + stitch.count) {
+          const positionInStitch = currentStitch - stitchIndex
+          
+          if (isIncreaseStitch(stitch.type)) {
+            // 加針類型：每個實際針目顯示為 2 個針目
+            displayNumber += positionInStitch * 2
+          } else {
+            // 一般針法：1:1 對應
+            displayNumber += positionInStitch
+          }
+          break
+        }
+        
+        // 累加已經完成的針目顯示數
+        if (isIncreaseStitch(stitch.type)) {
+          displayNumber += stitch.count * 2
+        } else {
+          displayNumber += stitch.count
+        }
+        
+        stitchIndex += stitch.count
+      } else if (item.type === PatternItemType.GROUP) {
+        const group = item.data as StitchGroup
+        
+        for (let repeat = 0; repeat < group.repeatCount; repeat++) {
+          for (const stitch of group.stitches) {
+            // 檢查當前針目是否在這個 stitch 範圍內
+            if (currentStitch >= stitchIndex && currentStitch < stitchIndex + stitch.count) {
+              const positionInStitch = currentStitch - stitchIndex
+              
+              if (isIncreaseStitch(stitch.type)) {
+                displayNumber += positionInStitch * 2
+              } else {
+                displayNumber += positionInStitch
+              }
+              return displayNumber
+            }
+            
+            // 累加已經完成的針目顯示數
+            if (isIncreaseStitch(stitch.type)) {
+              displayNumber += stitch.count * 2
+            } else {
+              displayNumber += stitch.count
+            }
+            
+            stitchIndex += stitch.count
+          }
+        }
+      }
+    }
+  } else {
+    // 向後兼容：使用舊格式
+    for (const stitch of displayRound.stitches) {
+      if (currentStitch >= stitchIndex && currentStitch < stitchIndex + stitch.count) {
+        const positionInStitch = currentStitch - stitchIndex
+        
+        if (isIncreaseStitch(stitch.type)) {
+          displayNumber += positionInStitch * 2
+        } else {
+          displayNumber += positionInStitch
+        }
+        return displayNumber
+      }
+      
+      if (isIncreaseStitch(stitch.type)) {
+        displayNumber += stitch.count * 2
+      } else {
+        displayNumber += stitch.count
+      }
+      
+      stitchIndex += stitch.count
+    }
+    
+    for (const group of displayRound.stitchGroups) {
+      for (let repeat = 0; repeat < group.repeatCount; repeat++) {
+        for (const stitch of group.stitches) {
+          if (currentStitch >= stitchIndex && currentStitch < stitchIndex + stitch.count) {
+            const positionInStitch = currentStitch - stitchIndex
+            
+            if (isIncreaseStitch(stitch.type)) {
+              displayNumber += positionInStitch * 2
+            } else {
+              displayNumber += positionInStitch
+            }
+            return displayNumber
+          }
+          
+          if (isIncreaseStitch(stitch.type)) {
+            displayNumber += stitch.count * 2
+          } else {
+            displayNumber += stitch.count
+          }
+          
+          stitchIndex += stitch.count
+        }
+      }
+    }
+  }
+
+  return displayNumber
+}


### PR DESCRIPTION
- Add isIncreaseStitch utility function to identify increase stitch types
- Separate currentStitchInRound (for progress tracking) from currentStitchDisplayInRound (for UI display)
- Implement calculateStitchDisplayNumber function with increase stitch logic
- Update ProgressActionButtons to use new currentStitchDisplayInRound for display
- Increase stitches now display +2 per actual stitch, maintaining accurate progress tracking